### PR TITLE
All branches should have tests run on server.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,7 +2,6 @@ name: Run tests
 
 on:
   push:
-    branches: [main, develop, releases/**]
     paths: ['**.py', '**.yml']
   pull_request:
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
I think tests should run on all branches, that way we know before a pr is done that it's ready.  It seems that the arguments that were here are anded together rather than ored so none of the tests were ran even though a pr was opened in #15 