### PR TITLE
Update volttron-lib-base-driver depedency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
-volttron-lib-base-driver = {git = "https://github.com/eclipse-volttron/volttron-lib-base-driver.git", branch = "develop"}
+volttron-lib-base-driver = "^0.1.1a0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^6.2.5"


### PR DESCRIPTION
The dependency volttron-lib-base-driver is currently pointing to a branch on github. Instead, the dependency should point to a wheel on PyPi. 