### PR TITLE
Start version number at 0.1.0 for pre-release

### DIFF
--- a/.github/workflows/deploy-pre-release.yml
+++ b/.github/workflows/deploy-pre-release.yml
@@ -84,7 +84,7 @@ jobs:
           # uses -V which is version sort to keep it monotonically increasing.
           current_tag=$(git tag -l "v*" | sort --reverse -V |sed -n 1p)
         else
-          current_tag=v10.0.0
+          current_tag=v0.1.0
         fi
 
         current_tag=${current_tag#?}


### PR DESCRIPTION
Before merging this PR, @craig8  please delete all releases at https://github.com/eclipse-volttron/volttron-platform-driver/releases
and tags at https://github.com/eclipse-volttron/volttron-platform-driver/tags to ensure that deploy-pre-release workflow will publish the correct version number on PyPi. 