### PR TITLE
Add IDENTITY to wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
     "Intended Audience :: Other Audience",
     "License :: OSI Approved :: Apache Software License"
 ]
+include = ["IDENTITY"]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"


### PR DESCRIPTION
When building the wheel that will be published to PyPi, the IDENTITY file is not included as part of the wheel. This PR ensures that it is. As a result of this change, a user should be able to run `vctl install volttron-platform-driver` and see the identity default to `platform.driver`. But there is a bug noted in the `vctl install` command at https://github.com/eclipse-volttron/volttron-core/issues/119. Right now, users should still follow the installation guidance in the README, namely to use `vctl install volttron-platform-driver --vip-identity platform.driver`


References:

https://python-poetry.org/docs/pyproject/#include-and-exclude
