### PR TITLE
Included default VIP identity file in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Intended Audience :: Other Audience",
     "License :: OSI Approved :: Apache Software License"
 ]
-include = ["volttron-platform-driver-*-default-vip-id"]
+include =[{path="volttron-platform-driver-default-vip-id", format = ["sdist", "wheel"]}]
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"


### PR DESCRIPTION
This pull request updates the package inclusion configuration in the `pyproject.toml` file to specify the format and path for included files. The change ensures that the `volttron-listener-default-vip-id` file is included in both source distributions and wheels, improving packaging consistency.

- Packaging configuration update:
  * Changed the `include` directive to explicitly specify `{path="volttron-listener-default-vip-id", format = ["sdist", "wheel"]}` in `pyproject.toml`, replacing the previous glob pattern.