### PR TITLE
Calls and plugins

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,9 +51,6 @@ agent_deps = [f'{d}{v}' for d, v in ppt['tool']['poetry'].get('dependencies', {}
 deps = base_deps + agent_deps
 run(['pip', 'install', *deps], check=True)
 
-# Install vdrv
-run(['python', 'setup_vdrv.py', 'install'])
-
 MAIN_MODULE = 'agent'
 
 # Find the agent package that contains the main module

--- a/src/platform_driver/agent.py
+++ b/src/platform_driver/agent.py
@@ -124,7 +124,7 @@ class PlatformDriverAgent(Agent):
     #########################
 
     @Core.receiver('onstop')
-    def _on_stop(self):
+    def _on_stop(self, _, **__):
         # TODO: Integrate this with greenlets other than heartbeat.
         self._stop_agent.set()
 
@@ -199,7 +199,7 @@ class PlatformDriverAgent(Agent):
                 or action == "NEW" or self.heartbeat_greenlet is None):
             if self.heartbeat_greenlet is not None:
                 self.heartbeat_greenlet.kill()
-            self.heartbeat_greenlet = self.core.spawn(self.heart_beat)
+            self.heartbeat_greenlet = gevent.spawn(self.heart_beat)
 
         # Start subscriptions:
         current_subscriptions = {topic: subscribed for _, topic, subscribed in self.vip.pubsub.list('pubsub').get()}
@@ -1079,6 +1079,9 @@ class PlatformDriverAgent(Agent):
         # TODO: Move this into the PollScheduler with configurable (per device) set of points and intervals (per-point).
         # TODO: config.heart_beat_point should be a set for each remote.
         while True:
+            if not self.equipment_tree.remotes:
+                gevent.sleep(self.config.remote_heartbeat_interval)
+                continue
             for remote in self.equipment_tree.remotes.values():
                 if self._stop_agent.is_set():
                     return

--- a/src/platform_driver/agent.py
+++ b/src/platform_driver/agent.py
@@ -30,6 +30,7 @@ import sys
 
 from collections import defaultdict
 from datetime import datetime
+from gevent.event import Event
 from importlib.metadata import distribution, PackageNotFoundError
 from pathlib import Path
 from pkgutil import iter_modules
@@ -51,7 +52,7 @@ try:
     from volttron.client.logs import setup_logging
     from volttron.client.messaging.health import STATUS_BAD
     from volttron.client.messaging.utils import normtopic
-    from volttron.client.vip.agent import Agent
+    from volttron.client.vip.agent import Agent, Core
     from volttron.client.vip.agent.subsystems.rpc import RPC
     from volttron.driver.base.driver import BaseInterface, DriverAgent
     from volttron.driver.base.driver_locks import configure_publish_lock, setup_socket_lock
@@ -65,7 +66,7 @@ except PackageNotFoundError:
     from volttron.platform.agent.known_identities import PLATFORM_DRIVER
     from volttron.platform.messaging.health import STATUS_BAD
     from volttron.platform.messaging.utils import normtopic
-    from volttron.platform.vip.agent import Agent
+    from volttron.platform.vip.agent import Agent, Core
     from volttron.platform.vip.agent.subsystems.rpc import RPC
     from volttron.driver.base.driver import BaseInterface, DriverAgent
     from volttron.driver.base.driver_locks import configure_publish_lock, setup_socket_lock
@@ -110,6 +111,7 @@ class PlatformDriverAgent(Agent):
         self.publishers = {}
         self.reservation_manager = None  # TODO: Should this use a default reservation manager?
         self.scalability_test = None
+        self._stop_agent = Event()
 
         self.vip.config.set_default("config", self.config.model_dump())
         self.vip.config.subscribe(self.configure_main, actions=['NEW', 'UPDATE', 'DELETE'], pattern='config')
@@ -120,6 +122,11 @@ class PlatformDriverAgent(Agent):
     #########################
     # Configuration & Startup
     #########################
+
+    @Core.receiver('onstop')
+    def _on_stop(self):
+        # TODO: Integrate this with greenlets other than heartbeat.
+        self._stop_agent.set()
 
     def _load_agent_config(self, config: dict) -> PlatformDriverConfig:
         try:
@@ -192,7 +199,7 @@ class PlatformDriverAgent(Agent):
                 or action == "NEW" or self.heartbeat_greenlet is None):
             if self.heartbeat_greenlet is not None:
                 self.heartbeat_greenlet.kill()
-            self.heartbeat_greenlet = self.core.periodic(self.config.remote_heartbeat_interval, self.heart_beat)
+            self.heartbeat_greenlet = self.core.spawn(self.heart_beat)
 
         # Start subscriptions:
         current_subscriptions = {topic: subscribed for _, topic, subscribed in self.vip.pubsub.list('pubsub').get()}
@@ -1069,14 +1076,18 @@ class PlatformDriverAgent(Agent):
         """
         Sends heartbeat to all devices
         """
-        # TODO: This should send to all remotes, collect tasks, and then log tasks after the fact.
         # TODO: Move this into the PollScheduler with configurable (per device) set of points and intervals (per-point).
-        _log.debug("sending heartbeat")
-        for remote in self.equipment_tree.remotes.values():
-            try:
-                remote.heart_beat()
-            except (Exception, gevent.Timeout) as e:
-                _log.warning(f'Failed to set heart_beat point on remote: {remote.unique_id} -- {e}.')
+        # TODO: config.heart_beat_point should be a set for each remote.
+        while True:
+            for remote in self.equipment_tree.remotes.values():
+                if self._stop_agent.is_set():
+                    return
+                try:
+                    remote.heart_beat()
+                except (Exception, gevent.Timeout) as e:
+                    _log.warning(f'Failed to set heart_beat point on remote: {remote.unique_id} -- {e}.')
+                finally:
+                    gevent.sleep(self.config.remote_heartbeat_interval / len(self.equipment_tree.remotes))
 
     @RPC.export
     def revert_point(self, path: str, point_name: str, **kwargs):


### PR DESCRIPTION
This pull request introduces several improvements to the `platform_driver` agent, focusing on better agent shutdown handling, improved heartbeat logic, and some dependency cleanup. The key changes involve using a `gevent` event to signal agent shutdown, refactoring the heartbeat mechanism to be more responsive to agent stop events, and removing an unnecessary installation step from `setup.py`.

**Agent shutdown and heartbeat improvements:**

* Added a `_stop_agent` event to the agent and a `@Core.receiver('onstop')` handler to set this event when the agent is stopping, enabling coordinated and graceful shutdown of greenlets. [[1]](diffhunk://#diff-ef599527830378672a9d4b1f2ca27a0d8112ecd57f43fc9c6880be04fbef5177R114) [[2]](diffhunk://#diff-ef599527830378672a9d4b1f2ca27a0d8112ecd57f43fc9c6880be04fbef5177R126-R130)
* Updated the `heart_beat` method to run in a loop, checking for the `_stop_agent` event and sleeping dynamically based on the number of remotes. This ensures heartbeats stop promptly when the agent is stopped and distributes the heartbeat interval across remotes.
* Changed the heartbeat greenlet to use `gevent.spawn` instead of `self.core.periodic`, giving more control over the heartbeat loop and its termination.

**Dependency and import updates:**

* Added import of `Event` from `gevent.event` to support the new shutdown mechanism.
* Updated imports to include `Core` from the appropriate `vip.agent` module for both client and platform contexts, enabling the use of the `@Core.receiver` decorator. [[1]](diffhunk://#diff-ef599527830378672a9d4b1f2ca27a0d8112ecd57f43fc9c6880be04fbef5177L54-R55) [[2]](diffhunk://#diff-ef599527830378672a9d4b1f2ca27a0d8112ecd57f43fc9c6880be04fbef5177L68-R69)

**Setup script cleanup:**

* Removed the installation of `vdrv` from `setup.py`, streamlining the setup process.