### PR TITLE
Stale fix

### DIFF
--- a/src/platform_driver/config.py
+++ b/src/platform_driver/config.py
@@ -80,7 +80,7 @@ class PlatformDriverConfig(BaseModel):
     scalability_test: bool = False
     scalability_test_iterations: int = 3
     stale_timeout_configured: Annotated[float | None, empty_str_is(None)] = Field(default=None, alias='stale_timeout')
-    stale_multiplier: Annotated[float, empty_str_is(3.0)] = Field(default=3.0)
+    stale_timeout_multiplier: Annotated[float, empty_str_is(3.0)] = Field(default=3.0)
     strict_all_publishes: bool = False
     timezone: str = 'UTC'  # TODO: Timezone needs integration (is is currently used in creating register metadata). The
                            #  driver has traditionally configured timezones at the device level, but these are not used

--- a/src/platform_driver/config.py
+++ b/src/platform_driver/config.py
@@ -25,7 +25,9 @@
 import logging
 from datetime import timedelta
 from pydantic import BaseModel, computed_field, ConfigDict, Field, model_validator
+from typing import Annotated
 
+from volttron.driver.base.config import empty_str_is
 
 _log = logging.getLogger()
 
@@ -77,6 +79,8 @@ class PlatformDriverConfig(BaseModel):
     reservation_required_for_write_configured: bool = Field(default=False, alias='reservation_required_for_write')
     scalability_test: bool = False
     scalability_test_iterations: int = 3
+    stale_timeout_configured: Annotated[float | None, empty_str_is(None)] = Field(default=None, alias='stale_timeout')
+    stale_multiplier: Annotated[float, empty_str_is(3.0)] = Field(default=3.0)
     strict_all_publishes: bool = False
     timezone: str = 'UTC'  # TODO: Timezone needs integration (is is currently used in creating register metadata). The
                            #  driver has traditionally configured timezones at the device level, but these are not used

--- a/src/platform_driver/equipment.py
+++ b/src/platform_driver/equipment.py
@@ -25,7 +25,7 @@
 import gevent
 import logging
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from importlib.metadata import distribution, PackageNotFoundError
 from treelib.exceptions import DuplicatedNodeIdError
 from typing import Any, cast, Iterable, Optional, TYPE_CHECKING, Union
@@ -222,8 +222,8 @@ class EquipmentTree(TopicTree):
         root_config.publish_multi_breadth = agent.config.publish_multi_breadth
         root_config.publish_all_depth = agent.config.publish_all_depth
         root_config.publish_all_breadth = agent.config.publish_all_breadth
-        root_config.sale_timeout_configured = agent.config.stale_timeout_configured
-        root_config.stale_multiplier = agent.config.stale_multiplier
+        root_config.stale_timeout_configured = agent.config.stale_timeout_configured
+        root_config.stale_timeout_multiplier = agent.config.stale_timeout_multiplier
         root_config.strict_all_publishes = agent.config.strict_all_publishes
 
     if TYPE_CHECKING:
@@ -416,6 +416,14 @@ class EquipmentTree(TopicTree):
     def get_polling_interval(self, nid: str) -> float:
         return self[next(self.rsearch(nid, lambda n: n.polling_interval is not None))].polling_interval
 
+    def get_stale_timeout_configured(self, nid: str) -> float | None:
+        return self[next(self.rsearch(nid, lambda n: n.config.stale_timeout_configured is not None),
+                  float('inf'))].config.stale_timeout_configured
+
+    def get_stale_timeout_multiplier(self, nid: str) -> float:
+        return self[next(self.rsearch(nid, lambda n: n.config.stale_timeout_multiplier is not None)
+                         )].config.stale_timeout_multiplier
+
     def is_published_single_depth(self, nid: str) -> bool:
         return self[next(self.rsearch(nid, lambda n: n.publish_single_depth is not None))].publish_single_depth
     
@@ -444,7 +452,16 @@ class EquipmentTree(TopicTree):
         return not any(p.last_updated is None for p in self.points(nid) if self.is_active(p.identifier))
 
     def is_stale(self, nid: str) -> bool:
-        stale_timeout = self[next(self.rsearch(nid, lambda n: n.stale_timeout is not None), float('inf'))].stale_timeout
+        stale_timeout_configured = self.get_stale_timeout_configured(nid)
+        stale_timeout_multiplier = self.get_stale_timeout_multiplier(nid)
+        polling_interval = self.get_polling_interval(nid)
+
+        if stale_timeout_configured is None and (polling_interval is None or stale_timeout_multiplier is None):
+                stale_timeout = float('inf')
+        else:
+            stale_timeout = timedelta(seconds=(stale_timeout_configured
+                                               if stale_timeout_configured is not None
+                                               else polling_interval * stale_timeout_multiplier))
         return True if get_aware_utc_now() - self.get_node(nid).last_updated > stale_timeout else False
 
     def active_points(self, points: EquipmentNode | Iterable[EquipmentNode]) -> Iterable[PointNode]:

--- a/src/platform_driver/equipment.py
+++ b/src/platform_driver/equipment.py
@@ -417,8 +417,8 @@ class EquipmentTree(TopicTree):
         return self[next(self.rsearch(nid, lambda n: n.polling_interval is not None))].polling_interval
 
     def get_stale_timeout_configured(self, nid: str) -> float | None:
-        return self[next(self.rsearch(nid, lambda n: n.config.stale_timeout_configured is not None),
-                  float('inf'))].config.stale_timeout_configured
+        node_with_value = next(self.rsearch(nid, lambda n: n.config.stale_timeout_configured is not None), None)
+        return self[node_with_value].config.stale_timeout_configured if node_with_value is not None else None
 
     def get_stale_timeout_multiplier(self, nid: str) -> float:
         return self[next(self.rsearch(nid, lambda n: n.config.stale_timeout_multiplier is not None)

--- a/src/platform_driver/equipment.py
+++ b/src/platform_driver/equipment.py
@@ -205,20 +205,6 @@ class PointNode(EquipmentNode):
     def last_updated(self) -> datetime:
         return self.data['last_updated']
 
-    @property
-    def stale(self) -> bool:
-        if self.data['config'].stale_timeout is None:
-            return False
-        else:
-            now = get_aware_utc_now()
-            # TODO: Logic was duplicated to add a debug statement. Decide if a permanent info/warning is required
-            #  here or elsewhere and get rid of second check.
-            if now - self.last_updated > self.data['config'].stale_timeout:
-                _log.debug(f'{self.tag} is stale --- now: {now}, last_updated: {self.last_updated},'
-                           f' stale_timeout: {self.data["config"].stale_timeout}, interval: {self.polling_interval}')
-            return True if get_aware_utc_now() - self.last_updated > self.data['config'].stale_timeout else False
-
-
 class EquipmentTree(TopicTree):
     def __init__(self, agent, *args, **kwargs):
         super(EquipmentTree, self).__init__(root_name=agent.config.depth_first_base, node_class=EquipmentNode,
@@ -236,6 +222,8 @@ class EquipmentTree(TopicTree):
         root_config.publish_multi_breadth = agent.config.publish_multi_breadth
         root_config.publish_all_depth = agent.config.publish_all_depth
         root_config.publish_all_breadth = agent.config.publish_all_breadth
+        root_config.sale_timeout_configured = agent.config.stale_timeout_configured
+        root_config.stale_multiplier = agent.config.stale_multiplier
         root_config.strict_all_publishes = agent.config.strict_all_publishes
 
     if TYPE_CHECKING:
@@ -456,7 +444,8 @@ class EquipmentTree(TopicTree):
         return not any(p.last_updated is None for p in self.points(nid) if self.is_active(p.identifier))
 
     def is_stale(self, nid: str) -> bool:
-        return any(p.stale for p in self.points(nid) if self.is_active(p.identifier))
+        stale_timeout = self[next(self.rsearch(nid, lambda n: n.stale_timeout is not None), float('inf'))].stale_timeout
+        return True if get_aware_utc_now() - self.get_node(nid).last_updated > stale_timeout else False
 
     def active_points(self, points: EquipmentNode | Iterable[EquipmentNode]) -> Iterable[PointNode]:
         points = self.points(points.identifier) if isinstance(points, EquipmentNode) else points
@@ -468,7 +457,7 @@ class EquipmentTree(TopicTree):
 
     def non_stale_points(self, points: EquipmentNode | Iterable[EquipmentNode]) -> Iterable[PointNode]:
         points = self.points(points.identifier) if isinstance(points, EquipmentNode) else points
-        return {p for p in points if not p.stale}
+        return {p for p in points if not self.is_stale(p.identifier)}
 
     def update_stored_registry_config(self, nid: str):
         # TODO: This updates the registry using JSON no matter what its original saved format was. This should be fine,


### PR DESCRIPTION
This pull request refactors how "stale" status is determined for equipment points by moving the staleness logic from individual nodes to the `EquipmentTree` class. It introduces new configuration options for staleness timeouts and multipliers, and updates the configuration and equipment management code to support these changes.

**Staleness Logic Refactor and Configuration Enhancements:**

* The logic for determining if a point is "stale" has been moved from the `EquipmentNode` property to the `EquipmentTree` class, centralizing the calculation and allowing for more flexible configuration. [[1]](diffhunk://#diff-8736d82c81a9eac39bac289fba006c352ecb1f3879339440eba2afeaeb2a59ceL208-L221) [[2]](diffhunk://#diff-8736d82c81a9eac39bac289fba006c352ecb1f3879339440eba2afeaeb2a59ceL459-R465)
* Added new configuration fields `stale_timeout_configured` and `stale_timeout_multiplier` to `PlatformDriverConfig`, allowing for explicit or computed staleness timeouts. These are also propagated to the root equipment configuration. [[1]](diffhunk://#diff-db3c46d9f951cacbaed13c3b9b2bf20764aa6902851d445dfa93817195644a36R82-R83) [[2]](diffhunk://#diff-8736d82c81a9eac39bac289fba006c352ecb1f3879339440eba2afeaeb2a59ceR225-R226)
* Implemented new methods in `EquipmentTree` to retrieve the staleness configuration values for nodes: `get_stale_timeout_configured` and `get_stale_timeout_multiplier`.

**Code Cleanup and Imports:**

* Cleaned up imports and removed the unused `stale` property from `EquipmentNode`. [[1]](diffhunk://#diff-8736d82c81a9eac39bac289fba006c352ecb1f3879339440eba2afeaeb2a59ceL28-R28) [[2]](diffhunk://#diff-8736d82c81a9eac39bac289fba006c352ecb1f3879339440eba2afeaeb2a59ceL208-L221)

**Behavioral Changes:**

* The `non_stale_points` method now uses the centralized `is_stale` logic, ensuring consistent staleness checks across the tree.