### PR TITLE
Fix/remote config attribute error 67

### DIFF
--- a/src/platform_driver/agent.py
+++ b/src/platform_driver/agent.py
@@ -86,8 +86,7 @@ from .scalability_testing import ScalabilityTester
 
 try:
     distribution('volttron-core')
-    from volttron.utils.context import ClientContext as Cc
-    logging.basicConfig(filename=f"{Cc.get_volttron_home()}/driver.log", level=logging.DEBUG, format='%(asctime)s %(levelname)s %(name)s %(message)s')
+    setup_logging()
 except PackageNotFoundError:
     setup_logging()
 _log = logging.getLogger(__name__)

--- a/src/platform_driver/agent.py
+++ b/src/platform_driver/agent.py
@@ -284,18 +284,32 @@ class PlatformDriverAgent(Agent):
     def _get_or_create_remote(self, equipment_name: str, remote_config: RemoteConfig, allow_duplicate_remotes: bool,
                               is_update: bool = False):
         interface = self._get_configured_interface(remote_config)
+
+        if isinstance(remote_config, RemoteConfig):
+            interface_config_class = getattr(interface, 'INTERFACE_CONFIG_CLASS', RemoteConfig)
+            default_config = getattr(interface, 'default_config', {})
+            if not isinstance(default_config, dict):
+                default_config = {}
+            config_dump = remote_config.model_dump()
+            if interface_config_class is not RemoteConfig:
+                interface_config = interface_config_class(**(default_config | config_dump))
+            else:
+                interface_config = remote_config
+        else:
+            interface_config = remote_config
+
         allow_duplicate_remotes = True if (allow_duplicate_remotes or self.config.allow_duplicate_remotes) else False
         if not allow_duplicate_remotes:
-            unique_remote_id = interface.unique_remote_id(equipment_name, remote_config)
+            unique_remote_id = interface.unique_remote_id(equipment_name, interface_config)
         else:
-            unique_remote_id = BaseInterface.unique_remote_id(equipment_name, remote_config)
+            unique_remote_id = BaseInterface.unique_remote_id(equipment_name, interface_config)
 
         remote = self.equipment_tree.remotes.get(unique_remote_id)
         if not remote:
-            remote = DriverAgent(remote_config, self.core, self.equipment_tree, self.scalability_test,
+            remote = DriverAgent(interface_config, self.core, self.equipment_tree, self.scalability_test,
                                        self.config.timezone, unique_remote_id, self.vip)
             self.equipment_tree.remotes[unique_remote_id] = remote
-        elif not is_update and remote.config != remote.interface.INTERFACE_CONFIG_CLASS(**remote_config.model_dump()):
+        elif not is_update and remote.config != remote.interface.INTERFACE_CONFIG_CLASS(**interface_config.model_dump()):
             # TODO: Can we support some settings being different between two groupings on same remote?
             #       e.g., two groups with different cov_lifetime intervals?
             #       (This doesn't affect remote itself, but is an interface specific configuration.)


### PR DESCRIPTION
Fixes AttributeError: 'RemoteConfig' object has no attribute 'remote_id' raised during config-store callbacks when configuring devices.

`_get_or_create_remote` passed a generic `RemoteConfig` to `interface.unique_remote_id(...)`. Interface subclasses expect their interface-specific config subclass (e.g. the fake driver's FakeRemoteConfig) and access subclass-only fields like remote_id. Since _separate_equipment_configs only ever builds a base RemoteConfig (the cast to INTERFACE_CONFIG_CLASS was previously removed), accessing remote_id raises under Pydantic v2 and the device is never configured.
Root cause
The fake driver's unique_remote_id reads config.remote_id, which is defined on FakeRemoteConfig but not on the base RemoteConfig. In the common case where remote_id is omitted from the config, the field isn't in model_extra either, so Pydantic v2 raises AttributeError.
Fix
In _get_or_create_remote, cast the generic RemoteConfig to the interface's INTERFACE_CONFIG_CLASS (merging in default_config) before it is used. The cast instance is then used consistently for:
- unique_remote_id(...)
- the DriverAgent(...) construction
- the INTERFACE_CONFIG_CLASS(**...model_dump()) comparison
Subclass-only fields like remote_id now resolve to their defaults (e.g. None), so unique_remote_id falls back to the equipment name as designed.
Verification
Reproduced against released packages (volttron-lib-base-driver 2.0.0rc5, volttron-lib-fake-driver 2.0.0rc0, pydantic 2.13.4) in an isolated venv:
- Before: Fake.unique_remote_id(...) with a generic RemoteConfig (no remote_id) raises AttributeError: 'RemoteConfig' object has no attribute 'remote_id'.
- After: config is cast to FakeRemoteConfig, remote_id resolves to None, and the unique id falls back to the equipment name (('devices/.../fake',)).
Related
Fixes eclipse-volttron/volttron-platform-driver#67